### PR TITLE
Allow empty signingPubKey to allow multisigned TXs

### DIFF
--- a/src/xrpParse.c
+++ b/src/xrpParse.c
@@ -157,7 +157,7 @@ parserStatus_e processVl(uint8_t *data, uint32_t length, txContent_t *context, u
     offset += 1 + 1;
     switch(fieldId) {
         case XRP_VL_SIGNING_PUB_KEY:
-            if (dataLength != 33) {
+            if (dataLength != 33 && dataLength != 0) {
                 goto error;
             }
             // TODO : check key


### PR DESCRIPTION
To successfully submit multisigned transactions to the XRP ledger, it must per definition include the SigningPubKey field as an empty string, thus it must be allowed to have length 0. See issue #4 for additional details.