### PR TITLE
Ble disconnect freeze fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1763,6 +1763,9 @@ void sample_main(void) {
 
                 handleApdu(&flags, &tx);
             }
+            CATCH(EXCEPTION_IO_RESET){
+                THROW(EXCEPTION_IO_RESET);
+            }
             CATCH_OTHER(e) {
                 switch (e & 0xF000) {
                 case 0x6000:


### PR DESCRIPTION
Catch EXCEPTION_IO_RESET in sample_main() for loop, and Throw EXCEPTION_IO_RESET to avoid device freeze at ble disconnection