### PR TITLE
Code scanning with CodeQL

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -11,14 +11,14 @@ jobs:
       image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build with Clang Static Analyzer
         run: |
           make clean
           scan-build --use-cc=clang -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -o scan-build --status-bugs make default
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: scan-build
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build Nano S app
         run: |
           make DEBUG=1
 
       - name: Upload app binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: app-debug-nanos
           path: bin
@@ -54,7 +54,7 @@ jobs:
           make DEBUG=1 BOLOS_SDK=$NANOX_SDK
 
       - name: Upload app binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: app-debug-nanox
           path: bin
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -103,13 +103,13 @@ jobs:
           apt-get install -qy netcat
 
       - name: Download Nano S app binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: app-debug-nanos
           path: bin-nanos
 
       - name: Download Nano X app binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: app-debug-nanox
           path: bin-nanox
@@ -128,7 +128,7 @@ jobs:
           pytest tests/
 
       - name: Upload speculos log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: speculos-nanos-log
@@ -152,7 +152,7 @@ jobs:
           pytest tests/
 
       - name: Upload speculos log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: speculos-nanox-log

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Build Nano S app
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           make DEBUG=1
 
       - name: Upload app binary

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,58 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "develop", master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "develop", master ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+        sdk: [ '$NANOS_SDK', '$NANOX_SDK', '$NANOSP_SDK' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-and-quality
+        
+    # CodeQL will create the database during the compilation
+    - name: Build
+      run: |
+        make BOLOS_SDK=${{ matrix.sdk }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint
         uses: DoozyX/clang-format-lint-action@v0.14

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -12,8 +12,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint
-        uses: DoozyX/clang-format-lint-action@v0.11
+        uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: './src'
           extensions: 'h,c'
-          clangFormatVersion: 11
+          clangFormatVersion: 14

--- a/src/xrp/amount.c
+++ b/src/xrp/amount.c
@@ -24,8 +24,8 @@
 #include "xrp_helpers.h"
 #include "readers.h"
 #include "number_helpers.h"
+#include "string_helpers.h"
 #include "../limitations.h"
-#include "strings.h"
 
 #define EXP_MIN      -96
 #define EXP_MAX      80
@@ -188,8 +188,8 @@ static void format_non_standard_currency(xrp_currency_t *currency, field_value_t
 }
 
 static int format_issued_currency(uint64_t value, char *buf, size_t size) {
-    uint8_t sign = (uint8_t)((value >> 62u) & 0x01u);
-    int16_t exponent = (int16_t)(((value >> 54u) & 0xFFu) - 97);
+    uint8_t sign = (uint8_t) ((value >> 62u) & 0x01u);
+    int16_t exponent = (int16_t) (((value >> 54u) & 0xFFu) - 97);
     uint64_t mantissa = value & 0x3FFFFFFFFFFFFFu;
     size_t len = strlen(buf);
     char *p;

--- a/src/xrp/amount.c
+++ b/src/xrp/amount.c
@@ -72,18 +72,18 @@ static int parse_decimal_number(char *dst,
         return -1;
     }
 
+    // 0. Abort early if number matches special case for zero
+    if (sign == 0 && exponent == 0 && mantissa == 0) {
+        dst[0] = '0';
+        return 0;
+    }
+
     if (exponent < EXP_MIN || exponent > EXP_MAX) {
         return -1;
     }
 
     if (mantissa < MANTISSA_MIN || mantissa > MANTISSA_MAX) {
         return -1;
-    }
-
-    // 0. Abort early if number matches special case for zero
-    if (sign == 0 && exponent == 0 && mantissa == 0) {
-        dst[0] = '0';
-        return 0;
     }
 
     // 1. Add leading minus sign if number is negative

--- a/src/xrp/general.c
+++ b/src/xrp/general.c
@@ -24,7 +24,7 @@
 #include "flags.h"
 #include "xrp_helpers.h"
 #include "time.h"
-#include "strings.h"
+#include "string_helpers.h"
 #include "../limitations.h"
 #include "transaction_types.h"
 #include "percentage.h"

--- a/src/xrp/string_helpers.c
+++ b/src/xrp/string_helpers.c
@@ -16,7 +16,7 @@
  *  limitations under the License.
  ********************************************************************************/
 
-#include "strings.h"
+#include "string_helpers.h"
 
 bool is_purely_ascii(const uint8_t *data, uint16_t length, bool allow_suffix) {
     bool tracking_suffix = false;

--- a/src/xrp/string_helpers.h
+++ b/src/xrp/string_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
-#include "fields.h"
+#include <stdint.h>
+#include <stdbool.h>
 
 bool is_purely_ascii(const uint8_t *data, uint16_t length, bool allow_suffix);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,8 +32,8 @@ add_library(xrp
   ../src/xrp/percentage.h
   ../src/xrp/readers.c
   ../src/xrp/readers.h
-  ../src/xrp/strings.c
-  ../src/xrp/strings.h
+  ../src/xrp/string_helpers.c
+  ../src/xrp/string_helpers.h
   ../src/xrp/time.c
   ../src/xrp/time.h
   ../src/xrp/transaction_types.h
@@ -60,7 +60,7 @@ add_executable(test_swap
   include/bolos_target.h
   include/cx.h
   include/os.h
-  )
+)
 
 add_executable(test_tx
   src/test_tx.c

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,2 @@
 pytest>=6.1.1,<7.0.0
-ledgerwallet>=0.1.2
-
-# This is a temporary fix for this issue: https://github.com/LedgerHQ/ledgerctl/issues/17
-# (fixed in https://github.com/LedgerHQ/ledgerctl/commit/cd30a2e8cefa7bb9b417b7c5f370fb26e8505f01).
-# This line could be removed once a new release of ledgerwallet > 0.1.2 includes this fix.
-construct==2.10.61
+ledgerwallet>=0.1.4


### PR DESCRIPTION
Set-up code scanning with CodeQL.

Bugfixes:

- "`strings.h`" has been renamed to prevent compilation warnings due to a name collision with a system header.
- Decimal parsing did not correctly handle special encoding for 0. This is fixed, although the whole function should be reworked.
- clang-formant lint action has been updated to take into account the provided `.clang-format` file (action failed while the code was correctly formatted...)
