### PR TITLE
Fix cx_hash_no_throw return value

### DIFF
--- a/src/apdu/messages/sign_transaction.c
+++ b/src/apdu/messages/sign_transaction.c
@@ -81,7 +81,7 @@ void sign_transaction() {
                                                 &private_key,
                                                 1));
         xrp_compress_public_key(&public_key, public_key_data);
-        xrp_public_key_hash160(public_key_data, suffix_data);
+        CX_CHECK(xrp_public_key_hash160(public_key_data, suffix_data));
 
         memmove(tmp_ctx.transaction_context.raw_tx + tmp_ctx.transaction_context.raw_tx_length,
                 suffix_data,

--- a/src/xrp/xrp_helpers.c
+++ b/src/xrp/xrp_helpers.c
@@ -78,17 +78,20 @@ static size_t xrp_encode_base58_address(const base58_buf_t *in, xrp_address_t *o
     return outlen;
 }
 
-void xrp_public_key_hash160(xrp_pubkey_t *pubkey, uint8_t *out) {
+cx_err_t xrp_public_key_hash160(xrp_pubkey_t *pubkey, uint8_t *out) {
     union {
         cx_sha256_t shasha;
         cx_ripemd160_t riprip;
     } u;
     uint8_t buffer[32];
+    cx_err_t error = CX_INTERNAL_ERROR;
 
     cx_sha256_init(&u.shasha);
-    cx_hash_no_throw(&u.shasha.header, CX_LAST, pubkey->buf, sizeof(pubkey->buf), buffer, 32);
+    error =
+        cx_hash_no_throw(&u.shasha.header, CX_LAST, pubkey->buf, sizeof(pubkey->buf), buffer, 32);
+    if (error != CX_OK) return error;
     cx_ripemd160_init(&u.riprip);
-    cx_hash_no_throw(&u.riprip.header, CX_LAST, buffer, 32, out, 20);
+    return cx_hash_no_throw(&u.riprip.header, CX_LAST, buffer, 32, out, 20);
 }
 
 size_t xrp_public_key_to_encoded_base58(xrp_pubkey_t *pubkey,
@@ -99,6 +102,7 @@ size_t xrp_public_key_to_encoded_base58(xrp_pubkey_t *pubkey,
     unsigned char checksum_buffer[32];
     cx_sha256_t hash;
     unsigned char version_size = (version > 255 ? 2 : 1);
+    cx_err_t error = CX_INTERNAL_ERROR;
 
     if (version > 255) {
         tmp.buf[0] = (version >> 8u);
@@ -108,16 +112,20 @@ size_t xrp_public_key_to_encoded_base58(xrp_pubkey_t *pubkey,
     }
 
     if (pubkey != NULL) {
-        xrp_public_key_hash160(pubkey, tmp.buf + version_size);
+        error = xrp_public_key_hash160(pubkey, tmp.buf + version_size);
+        if (error != CX_OK) return 0;
     }
     if (account != NULL) {
         memmove(tmp.buf + version_size, account->buf, sizeof(account->buf));
     }
 
     cx_sha256_init(&hash);
-    cx_hash_no_throw(&hash.header, CX_LAST, tmp.buf, 20 + version_size, checksum_buffer, 32);
+    error =
+        cx_hash_no_throw(&hash.header, CX_LAST, tmp.buf, 20 + version_size, checksum_buffer, 32);
+    if (error != CX_OK) return 0;
     cx_sha256_init(&hash);
-    cx_hash_no_throw(&hash.header, CX_LAST, checksum_buffer, 32, checksum_buffer, 32);
+    error = cx_hash_no_throw(&hash.header, CX_LAST, checksum_buffer, 32, checksum_buffer, 32);
+    if (error != CX_OK) return 0;
 
     memmove(tmp.buf + 20 + version_size, checksum_buffer, 4);
     tmp.length = 24 + version_size;

--- a/src/xrp/xrp_helpers.h
+++ b/src/xrp/xrp_helpers.h
@@ -39,7 +39,7 @@ typedef struct {
     char buf[XRP_ADDRESS_SIZE];
 } xrp_address_t;
 
-void xrp_public_key_hash160(xrp_pubkey_t *pubkey, uint8_t *out);
+cx_err_t xrp_public_key_hash160(xrp_pubkey_t *pubkey, uint8_t *out);
 
 size_t xrp_public_key_to_encoded_base58(xrp_pubkey_t *pubkey,
                                         xrp_account_t *account,

--- a/tests/include/cx.h
+++ b/tests/include/cx.h
@@ -5,6 +5,15 @@
 
 typedef unsigned int cx_curve_t;
 
+/** Success. */
+#define CX_OK 0x00000000
+
+/** Internal error */
+#define CX_INTERNAL_ERROR 0xFFFFFF85
+
+/** Type of error code */
+typedef uint32_t cx_err_t;
+
 #define CX_CURVE_256K1     0x1234
 #define CX_CURVE_SECP256K1 CX_CURVE_256K1
 


### PR DESCRIPTION
After `ledger-secure-sdk` commit "_Check return value for cx_hash_no_throw_", fix the error in `scan-build`.
Adapt the unit-tests accordingly

**Note**: The failed workflow "Swap functionnal tests" also fails on develop `branch`.